### PR TITLE
Add onInitialize callback

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -74,6 +74,9 @@ class RecPlayer extends Component {
       this.autoResize();
       urls.recUrl && cnt.loadReplay(urls.recUrl);
       cnt.player().setScale(this.props.zoom || 0.8);
+      if (props.onInitialize) {
+        props.onInitialize(cnt);
+      }
     });
   };
   autoResize = () => {


### PR DESCRIPTION
Add an optional `onInitialize = (controller) => void`  handler so that we can easily get the controller from recplayer after it's initialized. This is to access controller properties to do stuff that is currently not possible with the react component, like setting a specific frame or getting access to different controller states, etc. This can currently be done by using a reference to the component with `useRef` for example, but it is very hard to make it work consistently, since the way refs work in React.