### PR TITLE
add click for play/pause and dblclick for fullscreen

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -180,6 +180,16 @@ class RecPlayer extends Component {
   playerContainerOnTap = () => {
     this.playerContainer.focus();
   };
+  onClick = e => {
+    if (e.target.localName === 'canvas') {
+      this.playPause();
+    }
+  }
+  onDoubleClick = e => {
+    if (e.target.localName === 'canvas') {
+      this.fullscreen();
+    }
+  }
   render() {
     let className = this.state.fullscreen
       ? "RecPlayer RecPlayer-fullscreen"
@@ -195,6 +205,8 @@ class RecPlayer extends Component {
           width: this.props.width === "auto" ? "100%" : this.props.width + "px"
         }}
         className={className}
+        onClick={this.onClick}
+        onDoubleClick={this.onDoubleClick}
       >
         <div
           className="RecPlayer-player-container"


### PR DESCRIPTION
Closes #8 

Checks for localName canvas so it doesn't execute when clicking the controls

Currently it will do a play and pause when you doubleclick for fullscreen. Could add a delay where it checks if doubleclick is happening but then there would be a delay when doing normal click. Not sure which is best but this was less code so went with it.