### PR TITLE
Add wakeLock support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ import RecPlayer from "recplayer-react";
   zoom={0.7}
   controls
   autoPlay
+  wakeLock
   imageUrl="http://www.recsource.tv/images"
   onInitialize={cnt => someFunction(cnt)}
   levelOptions={{
@@ -28,4 +29,4 @@ import RecPlayer from "recplayer-react";
 />
 ```
 
-The `width` and `height` properties can be set either as pixel values, or as "auto" in which case the player will be resized to the size of the parent element. The `zoom` property sets the initial zoom level of the player. The `recUrl` and `levUrl` are of course the urls of the files that should be loaded. If you add `controls` property to the component player controls will be overlaid on the player. With `autoPlay` property you can control whether the the playback of the replay will start automatically or not, default value is `false`. You can pass in a custom url where the recplayer will load the images with the `imageUrl` property.
+The `width` and `height` properties can be set either as pixel values, or as "auto" in which case the player will be resized to the size of the parent element. The `zoom` property sets the initial zoom level of the player. The `recUrl` and `levUrl` are of course the urls of the files that should be loaded. If you add `controls` property to the component player controls will be overlaid on the player. With `autoPlay` property you can control whether the the playback of the replay will start automatically or not, default value is `false`. You can pass in a custom url where the recplayer will load the images with the `imageUrl` property. Use `wakeLock` prop to prevent display going off during a replay playback (implemented using the wakeLock api https://developer.mozilla.org/en-US/docs/Web/API/Screen_Wake_Lock_API)


### PR DESCRIPTION
This PR adds the wakeLock prop to the recplayer component. WakeLock is effective only when the prop is set and a replay is playing on an active tab. Seemed to work nicely on my laptop, couldn't test on a mobile device since I think it needs a https connection to work.